### PR TITLE
Add Dockerfile and docker compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+vendor
+source
+.themes
+.sass-cache
+.pygments-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx:1.7.10
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY public /sites/bruntonspall
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM nginx:1.7.10
+MAINTAINER Michael Brunton-Spall <michael@brunton-spall.co.uk>
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY public /sites/bruntonspall
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,9 @@
+server {
+  listen   80;
+  server_name  www.brunton-spall.co.uk;
+
+  location / {
+    root   /sites/bruntonspall;
+    index  index.html index.htm default.htm default.html;
+  }
+}


### PR DESCRIPTION
It would be awesome to build a dockerfile that consists of an nginx that can just serve the static content.

In comparison to other octopress dockerfiles I've seen, this one is entirely runtime based, it has no capability to rebuild the site, so it is expected that the rake generate step is done at build time, with the docker image being created post-build.

This means that in a CI system, we can have one process generate the static code, and a second process generate the docker images and push them to a docker hub.  This makes the docker images much smaller and simpler, neatly dividing the responsibility between runtime and buildtime.
